### PR TITLE
feat: Add `success` in default type

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -48,6 +48,7 @@ export interface IDefaultTypes extends ITypes {
   warn: IType;
   error: IType;
   fatal: IType;
+  success: IType;
 }
 
 /**


### PR DESCRIPTION
Add `success` in [`IDefaultTypes`](https://github.com/WoLfulus/zoya/blob/26dcf79b967c201582e69595ba5d3ac3b5b9b0f7/src/options.ts#L44).

Fix https://github.com/WoLfulus/zoya/issues/46#issuecomment-678770005.